### PR TITLE
Fix query for older Solr versions

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -85,7 +85,7 @@ Client.prototype._requestGet = function(path, query, finalCallback) {
     params = 'q=*:*';
   }
   requestPrefixUrl = this._makeHostUrl(this.options.protocol, this.options.host, this.options.port);
-  requestPrefixUrl += '/' + [this.options.rootPath, this.options.core, path].join('/');
+  requestPrefixUrl += '/' + [this.options.rootPath, this.options.core, path].filter(function (e) { return e; }).join('/');
 
   requestFullPath = requestPrefixUrl + '?' + params;
 
@@ -141,7 +141,7 @@ Client.prototype._requestPost = function(path, data, urlOptions, finalCallback) 
   }
 
   requestPrefixUrl = this._makeHostUrl(this.options.protocol, this.options.host, this.options.port);
-  requestPrefixUrl += '/' + [this.options.rootPath, this.options.core, path].join('/');
+  requestPrefixUrl += '/' + [this.options.rootPath, this.options.core, path].filter(function (e) { return e; }).join('/');
 
   requestFullPath = requestPrefixUrl + '?' + params;
 


### PR DESCRIPTION
On older solr the endpoints are not prefixed by the core name.
This fix ensures that the requests without a core name are: `/solr/select` instead of `/solr//select/`