### PR TITLE
Fix typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,6 @@ declare module 'solr-node' {
       core?: string;
       rootPath?: string;
       protocol?: string;
-      debugLevel?: 'ALL' | 'DEBUG' | 'INFO' | 'ERROR';
     }
 
     interface UpdateOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module 'solr-node' {
       df(params: string): this;
       wt(params: string): this;
       addParams(params: Array<{ field: string; value: any }>): this;
-      spatial(params: Array<{ pt: string; sfield: string; d: string }>): this;
+      spatial(params: { pt: string; sfield: string; d: string | number }): this;
       termsQuery(params: TermsQueryParams | string): this;
       mltQuery(params: MoreLikeThisQueryParams | string): this;
       spellcheckQuery(params: SpellcheckQueryParams | string): this;
@@ -51,6 +51,7 @@ declare module 'solr-node' {
         start: number;
         docs: T[];
       };
+      nextCursorMark?: string;
     }
 
     interface ClientOptions {

--- a/lib/query.js
+++ b/lib/query.js
@@ -236,10 +236,10 @@ Query.prototype.addParams = function (params) {
 /**
  * Spatial
  *
- * @param {Object[]} params
+ * @param {Object} params
  * @param {String} params.pt - params pt
  * @param {String} params.sfield - params sfield
- * @param {String} params.d - params d
+ * @param {String|Number} params.d - params d
  *
  * @returns {Query}
  */


### PR DESCRIPTION
Looking into code, Query.spatial accepts an object or string as an input.
Added support for nextCursorMark in the response from solr.