### PR TITLE
Add configuration option for setting solr endpoint by single connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ var client = new SolrNode({
     protocol: 'http'
 });
 
+// or
+
+var client = new SolrNode('http://127.0.0.1:8983/solr/test');
+
 // Set logger level (can be set to DEBUG, INFO, WARN, ERROR, FATAL or OFF)
 require('log4js').getLogger('solr-node').level = 'DEBUG';
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'solr-node' {
   class Client {
-    constructor(options: Client.ClientOptions);
+    constructor(options: Client.ClientOptions | string);
 
     query(): Client.Query;
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,7 +16,7 @@ var _ = require('underscore'),
  *
  * @constructor
  *
- * @param {Object} options
+ * @param {String|Object} options - an URL to Solr server core - example: 'http://127.0.0.1:8983/solr/test'
  * @param {String} [options.host] - host address of Solr server
  * @param {Number|String} [options.port] - port number of Solr server
  * @param {String} [options.core] - client core name
@@ -24,13 +24,17 @@ var _ = require('underscore'),
  * @param {String} [options.protocol] - request protocol ('http'|'https')
  */
 function Client(options) {
-  this.options = {
-    host: options.host || '127.0.0.1',
-    port: options.port || '8983',
-    core: options.core || '',
-    rootPath: options.rootPath || 'solr',
-    protocol: options.protocol || 'http'
-  };
+  if (_.isObject(options)) {
+    var host = options.host || '127.0.0.1';
+    var port = options.port || '8983';
+    var core = options.core || '';
+    var rootPath = options.rootPath || 'solr';
+    var protocol = options.protocol || 'http';
+
+    this.solrEndpointUrl = this._makeHostUrl(protocol, host, port) + '/' + rootPath+ '/' + core;
+  } else {
+    this.solrEndpointUrl = options || '';
+  }
 
   // Path Constants List
   this.SEARCH_PATH = 'select';
@@ -103,7 +107,7 @@ Client.prototype._callSolrServer = function(requestFullPath, fetchOptions, final
  * @returns {undefined|Promise} - When there's no callback function it returns a Promise
  */
 Client.prototype._requestGet = function(path, query, finalCallback) {
-  var params, options, requestPrefixUrl, requestFullPath;
+  var params, options, requestUrl;
 
   if (query instanceof Query) {
     params = query.toString();
@@ -112,12 +116,9 @@ Client.prototype._requestGet = function(path, query, finalCallback) {
   } else {
     params = 'q=*:*';
   }
-  requestPrefixUrl = this._makeHostUrl(this.options.protocol, this.options.host, this.options.port);
-  requestPrefixUrl += '/' + [this.options.rootPath, this.options.core, path].join('/');
+  requestUrl = this.solrEndpointUrl + '/' + path + '?' + params;
 
-  requestFullPath = requestPrefixUrl + '?' + params;
-
-  logger.debug('[_requestGet] requestFullPath: ', requestFullPath);
+  logger.debug('[_requestGet] requestUrl: ', requestUrl);
 
   options = {
     method: 'GET',
@@ -126,7 +127,7 @@ Client.prototype._requestGet = function(path, query, finalCallback) {
     }
   };
 
-  return this._callSolrServer(requestFullPath, options, finalCallback);
+  return this._callSolrServer(requestUrl, options, finalCallback);
 };
 
 /**
@@ -140,7 +141,7 @@ Client.prototype._requestGet = function(path, query, finalCallback) {
  * @returns {undefined|Promise} - When there's no callback function it returns a Promise
  */
 Client.prototype._requestPost = function(path, data, urlOptions, finalCallback) {
-  var params, options, requestPrefixUrl, requestFullPath;
+  var params, options, requestUrl;
 
   if (_.isString(urlOptions)) {
     params = urlOptions;
@@ -150,12 +151,9 @@ Client.prototype._requestPost = function(path, data, urlOptions, finalCallback) 
     params = '';
   }
 
-  requestPrefixUrl = this._makeHostUrl(this.options.protocol, this.options.host, this.options.port);
-  requestPrefixUrl += '/' + [this.options.rootPath, this.options.core, path].join('/');
+  requestUrl = this.solrEndpointUrl + '/' + path + '?' + params;
 
-  requestFullPath = requestPrefixUrl + '?' + params;
-
-  logger.debug('[_requestPost] requestFullPath: ', requestFullPath);
+  logger.debug('[_requestPost] requestUrl: ', requestUrl);
   logger.debug('[_requestPost] data: ', data);
 
   options = {
@@ -167,7 +165,7 @@ Client.prototype._requestPost = function(path, data, urlOptions, finalCallback) 
     }
   };
 
-  return this._callSolrServer(requestFullPath, options, finalCallback);
+  return this._callSolrServer(requestUrl, options, finalCallback);
 };
 
 /**

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -166,13 +166,7 @@ describe('Client', function() {
       //when
       var client = new Client(options);
       //then
-      expect(client.options).to.eql({
-        host: '127.0.0.1',
-        port: '8983',
-        core: '',
-        rootPath: 'solr',
-        protocol: 'http'
-      });
+      expect(client.solrEndpointUrl).to.eql('http://127.0.0.1:8983/solr/');
     });
 
     it('should create client when core:"test".', function() {
@@ -183,13 +177,16 @@ describe('Client', function() {
       //when
       var client = new Client(options);
       //then
-      expect(client.options).to.eql({
-        host: '127.0.0.1',
-        port: '8983',
-        core: 'test',
-        rootPath: 'solr',
-        protocol: 'http'
-      });
+      expect(client.solrEndpointUrl).to.eql('http://127.0.0.1:8983/solr/test');
+    });
+
+    it('should create client when solr endpoint given as a string', function() {
+      //given
+      var options = 'http://test.com/solr/test';
+      //when
+      var client = new Client(options);
+      //then
+      expect(client.solrEndpointUrl).to.eql('http://test.com/solr/test');
     });
   });
 


### PR DESCRIPTION
Single configuration option for solr endpoint will make integration with other projects easier.
