### PR TITLE
Added hl.method param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -154,6 +154,7 @@ declare module 'solr-node' {
     interface HighlightQueryParams {
       on?: boolean;
       q?: string;
+      method?: string;
       qparser?: string;
       fl: string | string[];
       snippets?: number;

--- a/lib/query.js
+++ b/lib/query.js
@@ -696,6 +696,7 @@ Query.prototype.groupQuery = function(params) {
  *
  * @param {Object|String} params - hl object or hl string
  * @param {Boolean} [params.on=true] - Turn on or off hl
+ * @param {String} [params.method] - Specifies the highlighting implementation to use, acceptables values are unified, original, fastVector, and postings
  * @param {String} [params.q] - Specifies an overriding query term for highlighting
  * @param {String} [params.qparser] - Specifies a qparser to use for the hl.q query.
  * @param {String|Array} [params.fl] - Specifies a list of fields to highlight.
@@ -738,7 +739,9 @@ Query.prototype.hlQuery = function(params) {
   } else {
     self.params.push('hl=true');
   }
-
+  if (!_.isUndefined(params.method)) {
+      self.params.push('hl.method=' + params.method);
+  }
   if (!_.isUndefined(params.q)) {
     self.params.push('hl.q=' + params.q);
   }


### PR DESCRIPTION
HighlightQueryParams was missing the method property, used to specifies which implementation of the highlighting will be used.