### PR TITLE
line 36 has been changed in https://github.com/godong9/solr-node/pull…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,7 +122,7 @@ declare module 'solr-node' {
       accuracy?: number;
     }
 
-    interface SuggestParams {
+    interface SuggestQueryParams {
       on?: boolean;
       q: string;
       build?: boolean;


### PR DESCRIPTION
in pr https://github.com/godong9/solr-node/pull/84 the line 36 of the index.d.ts has been changed to `suggestQuery(params: SuggestQueryParams | string): this;` however the interface itself on line 125 wasn't changed.

This causes transpile errors in my ts project.

this pr rectifies this, and hopefully this will allow us to use the package in the future, and we won't have to keep a forked version of this in our dependencies.