### PR TITLE
fix up fq param types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,7 +122,7 @@ declare module 'solr-node' {
       accuracy?: number;
     }
 
-    interface SuggestParams {
+    interface SuggestQueryParams {
       on?: boolean;
       q: string;
       build?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare module 'solr-node' {
       start(params: string | number): this;
       rows(params: string | number): this;
       sort(params: object): this;
-      fq(params: string): this;
+      fq(params: object | object[]): this;
       df(params: string): this;
       wt(params: string): this;
       addParams(params: Array<{ field: string; value: any }>): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare module 'solr-node' {
       start(params: string | number): this;
       rows(params: string | number): this;
       sort(params: object): this;
-      fq(params: object | object[]): this;
+      fq(params: FilterQueryParam | FilterQueryParam[]): this;
       df(params: string): this;
       wt(params: string): this;
       addParams(params: Array<{ field: string; value: any }>): this;
@@ -185,6 +185,11 @@ declare module 'solr-node' {
       regexPattern?: string;
       regexMaxAnalyzedChars?: number;
       preserveMulti?: boolean;
+    }
+
+    interface FilterQueryParam {
+      field: string;
+      value: string | number;
     }
   }
 


### PR DESCRIPTION
As you can see in lib/query.js line 157 and 176 a filter query never really expects a string, only an object with field and value.

If I'd send a string to fq() id get a compile error. 